### PR TITLE
Hotfix/scheduler stats fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/stats/PerformanceStatsJob.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/stats/PerformanceStatsJob.java
@@ -30,7 +30,7 @@ public class PerformanceStatsJob extends ParallelJob {
                 Set.of(metaData -> runRunProcedure("auto_processed"))),
             new ResultSupplier(false,
                 Set.of(
-                    metaData -> runRunProcedure("response_times_and_non_respond",
+                    metaData -> runRunProcedure("response_times_and_not_responded",
                         this.config.getResponseTimesAndNonRespondNoMonths()),
                     metaData -> runRunProcedure("unprocessed_responses"),
                     metaData -> runRunProcedure("welsh_online_responses",

--- a/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/stats/PerformanceStatsJob.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/stats/PerformanceStatsJob.java
@@ -27,19 +27,19 @@ public class PerformanceStatsJob extends ParallelJob {
     public List<ResultSupplier> getResultSuppliers() {
         return List.of(
             new ResultSupplier(false,
-                Set.of(metaData -> runRunProcedure("refresh_stats_data.auto_processed"))),
+                Set.of(metaData -> runRunProcedure("auto_processed"))),
             new ResultSupplier(false,
                 Set.of(
-                    metaData -> runRunProcedure("refresh_stats_data.response_times_and_non_respond",
+                    metaData -> runRunProcedure("response_times_and_non_respond",
                         this.config.getResponseTimesAndNonRespondNoMonths()),
-                    metaData -> runRunProcedure("refresh_stats_data.unprocessed_responses"),
-                    metaData -> runRunProcedure("refresh_stats_data.welsh_online_responses",
+                    metaData -> runRunProcedure("unprocessed_responses"),
+                    metaData -> runRunProcedure("welsh_online_responses",
                         this.config.getWelshOnlineResponsesNoMonths()),
-                    metaData -> runRunProcedure("refresh_stats_data.thirdparty_online",
+                    metaData -> runRunProcedure("thirdparty_online",
                         this.config.getThirdpartyOnlineNoMonths()),
-                    metaData -> runRunProcedure("refresh_stats_data.deferrals",
+                    metaData -> runRunProcedure("deferrals",
                         this.config.getDeferralsNoMonths()),
-                    metaData -> runRunProcedure("refresh_stats_data.excusals",
+                    metaData -> runRunProcedure("excusals",
                         this.config.getExcusalsNoMonths())
                 )
             )

--- a/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/stats/PerformanceStatsJobTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/stats/PerformanceStatsJobTest.java
@@ -79,8 +79,8 @@ class PerformanceStatsJobTest {
         Function<MetaData, Job.Result> runner1 = resultSupplier1.getResultRunners().iterator().next();
         runner1.apply(metaData);
         verify(performanceStatsJob, times(1))
-            .runRunProcedure("refresh_stats_data.auto_processed");
-        verifyNoMoreInteractions(databaseService);
+            .runRunProcedure("auto_processed");
+        verifyNoMoreInteractions(databaseService, smtpService);
         verifyNoMoreInteractions(performanceStatsJob);
 
 
@@ -94,21 +94,21 @@ class PerformanceStatsJobTest {
             runner.apply(metaData);
         }
         verify(performanceStatsJob, times(1))
-            .runRunProcedure("refresh_stats_data.response_times_and_non_respond",
+            .runRunProcedure("response_times_and_not_responded",
                 this.config.getResponseTimesAndNonRespondNoMonths());
         verify(performanceStatsJob, times(1))
-            .runRunProcedure("refresh_stats_data.unprocessed_responses");
+            .runRunProcedure("unprocessed_responses");
         verify(performanceStatsJob, times(1))
-            .runRunProcedure("refresh_stats_data.welsh_online_responses",
+            .runRunProcedure("welsh_online_responses",
                 this.config.getWelshOnlineResponsesNoMonths());
         verify(performanceStatsJob, times(1))
-            .runRunProcedure("refresh_stats_data.thirdparty_online",
+            .runRunProcedure("thirdparty_online",
                 this.config.getThirdpartyOnlineNoMonths());
         verify(performanceStatsJob, times(1))
-            .runRunProcedure("refresh_stats_data.deferrals",
+            .runRunProcedure("deferrals",
                 this.config.getDeferralsNoMonths());
         verify(performanceStatsJob, times(1))
-            .runRunProcedure("refresh_stats_data.excusals",
+            .runRunProcedure("excusals",
                 this.config.getExcusalsNoMonths());
 
         verifyNoMoreInteractions(databaseService);

--- a/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/stats/PerformanceStatsJobTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/stats/PerformanceStatsJobTest.java
@@ -80,7 +80,7 @@ class PerformanceStatsJobTest {
         runner1.apply(metaData);
         verify(performanceStatsJob, times(1))
             .runRunProcedure("auto_processed");
-        verifyNoMoreInteractions(databaseService, smtpService);
+        verifyNoMoreInteractions(databaseService);
         verifyNoMoreInteractions(performanceStatsJob);
 
 


### PR DESCRIPTION
### Change description ###
Removed schema "refresh_stats" as the stored procedures live in the juror_dashboard schema
Fixed spelling of procedure call


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
