### PR TITLE
SCHEDULER: failed_file_transfer set incorrectly if upload fails

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/job/execution/database/model/ContentStore.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/database/model/ContentStore.java
@@ -18,5 +18,9 @@ public class ContentStore {
     private String data;
     @DatabaseColumn(name = "FAILED_FILE_TRANSFER", setter = "setFailedFileTransfer")
     private Boolean failedFileTransfer;
+
+    public boolean isFailedFileTransfer() {
+        return failedFileTransfer != null && failedFileTransfer;
+    }
 }
 

--- a/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/ContentStoreFileJobTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/ContentStoreFileJobTest.java
@@ -225,7 +225,7 @@ public class ContentStoreFileJobTest {
                 verify(databaseService, times(1))
                     .execute(eq(databaseConfig), any());
 
-                verify(databaseService, times(1))
+                verify(databaseService, never())
                     .executeStoredProcedure(connection, procedureName, procedureArguments);
 
                 verify(databaseService, times(1))
@@ -387,7 +387,7 @@ public class ContentStoreFileJobTest {
             + "WHERE DOCUMENT_ID=? AND FILE_TYPE=?";
 
         private static final String UPDATE_SQL_FAILED_QUERY = "UPDATE CONTENT_STORE "
-            + "SET CS.FAILED_FILE_TRANSFER=true "
+            + "SET FAILED_FILE_TRANSFER=true "
             + "WHERE DOCUMENT_ID=? AND FILE_TYPE=?";
 
         @Test


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7634)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
We ran PRINT_JOB and it failed - we assume because BAIS was down. The job incorrectly set failed_file_transfer to NULL when it should have set it to true.

!image-20240621-140658.png|width=1390,height=409,alt="image-20240621-140658.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
