### PR TITLE
Incorrect heading in dashboard data

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/dashboard/ams/data/BureauLettersAutomaticallyGenerated.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/dashboard/ams/data/BureauLettersAutomaticallyGenerated.java
@@ -32,7 +32,7 @@ public class BureauLettersAutomaticallyGenerated extends DashboardDataEntry {
                                                   DatabaseService databaseService,
                                                   DatabaseConfig databaseConfig,
                                                   Clock clock) {
-        super(dashboardData, "Bureau Letters Automatically Generated", WITHDRAWAL, CONFIRMATION);
+        super(dashboardData, "Bureau Letters Automatically Generated", "Type", "Count");
         this.databaseService = databaseService;
         this.databaseConfig = databaseConfig;
         this.clock = clock;

--- a/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/dashboard/ams/data/BureauLettersAutomaticallyGeneratedTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/dashboard/ams/data/BureauLettersAutomaticallyGeneratedTest.java
@@ -52,8 +52,8 @@ class BureauLettersAutomaticallyGeneratedTest {
         assertEquals(2, bureauLettersAutomaticallyGenerated.columCount,
             "Expected column count to be 2");
         assertEquals(2, bureauLettersAutomaticallyGenerated.rows.get(0).length);
-        assertEquals("Withdrawal", bureauLettersAutomaticallyGenerated.rows.get(0)[0]);
-        assertEquals("Confirmation", bureauLettersAutomaticallyGenerated.rows.get(0)[1]);
+        assertEquals("Type", bureauLettersAutomaticallyGenerated.rows.get(0)[0]);
+        assertEquals("Count", bureauLettersAutomaticallyGenerated.rows.get(0)[1]);
     }
 
     @Test


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7698)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
Live feed has got different header(Type,Count):

[Bureau Letters Automatically Generated]
*Type,Count*
CONFIRMATION,2321
WITHDRAWAL,8

 

MOD feed has got:

[Bureau Letters Automatically Generated]
*Withdrawal,Confirmation*
Withdrawal,0
Confirmation,0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
