### PR TITLE
Print and Payment File copy to BAIS not Retrying

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/ContentStoreFileJob.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/ContentStoreFileJob.java
@@ -51,6 +51,7 @@ public abstract class ContentStoreFileJob extends LinearJob {
     private final long retryLimit;
     private final long retryDelay;
 
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     protected ContentStoreFileJob(
         SftpService sftpService,
         DatabaseService databaseService,

--- a/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/payment/PaymentConfig.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/payment/PaymentConfig.java
@@ -25,4 +25,7 @@ public class PaymentConfig implements HasDatabaseConfig, HasSftpConfig {
     private DatabaseConfig database;
     @NotNull
     private File ftpDirectory;
+
+    private long retryLimit;
+    private long retryDelay;
 }

--- a/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/payment/PaymentFileJob.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/payment/PaymentFileJob.java
@@ -23,6 +23,8 @@ public class PaymentFileJob extends ContentStoreFileJob {
             "payment_files_to_clob",
             new Object[0],
             "\\d+.*\\d{13}\\.dat",
-            PaymentSftp.class);
+            PaymentSftp.class,
+            paymentConfig.getRetryLimit(),
+            paymentConfig.getRetryDelay());
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/print/PrintConfig.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/print/PrintConfig.java
@@ -27,4 +27,7 @@ public class PrintConfig implements HasDatabaseConfig, HasSftpConfig {
     private Integer printFileRowLimit;
     @NotNull
     private File ftpDirectory;
+
+    private long retryLimit;
+    private long retryDelay;
 }

--- a/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/print/PrintFileJob.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/print/PrintFileJob.java
@@ -23,6 +23,8 @@ public class PrintFileJob extends ContentStoreFileJob {
             "printfiles_to_clob",
             new Object[]{printConfig.getPrintFileRowLimit()},
             "JURY\\d+\\.\\d+.*",
-            PrintSftp.class);
+            PrintSftp.class,
+            printConfig.getRetryLimit(),
+            printConfig.getRetryDelay());
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/job/execution/service/SftpServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/service/SftpServiceImpl.java
@@ -65,7 +65,7 @@ public class SftpServiceImpl implements SftpService {
                 return true;
             }
             retryCount++;
-        } while (retryLimit > 0 && retryCount < retryLimit);
+        } while (retryLimit > 0 && retryCount <= retryLimit);
         return false;
     }
 

--- a/src/main/java/uk/gov/hmcts/juror/job/execution/service/contracts/SftpService.java
+++ b/src/main/java/uk/gov/hmcts/juror/job/execution/service/contracts/SftpService.java
@@ -6,7 +6,16 @@ import java.io.File;
 import java.util.Collection;
 
 public interface SftpService {
-    Collection<File> upload(Class<? extends Sftp> sftpClass, Collection<File> filesToProcess);
+    default Collection<File> upload(Class<? extends Sftp> sftpClass, Collection<File> filesToProcess) {
+        return upload(sftpClass, filesToProcess, 0, 0);
+    }
 
-    boolean upload(Class<? extends Sftp> sftpClass, File fileToProcess);
+    Collection<File> upload(Class<? extends Sftp> sftpClass, Collection<File> filesToProcess,
+                            long retryLimit, long retryDelay);
+
+    default boolean upload(Class<? extends Sftp> sftpClass, File fileToProcess) {
+        return upload(sftpClass, fileToProcess, 0, 0);
+    }
+
+    boolean upload(Class<? extends Sftp> sftpClass, File fileToProcess, long retryLimit, long retryDelay);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -95,6 +95,8 @@ jobs:
       schema: juror_mod
   print:
     ftp-directory: /tmp/ftp_print
+    retry-limit: 3
+    retry-delay: 95000
     sftp:
       host: ${BAIS_HOST:localhost}
       port: ${BAIS_PORT:2222}
@@ -108,6 +110,8 @@ jobs:
     print-file-row-limit: 2000
   payment:
     ftp-directory: /tmp/ftp_payment
+    retry-limit: 5
+    retry-delay: 10000
     sftp:
       host: ${BAIS_HOST:localhost}
       port: ${BAIS_PORT:2222}

--- a/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/ContentStoreFileJobTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/ContentStoreFileJobTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -408,7 +409,8 @@ public class ContentStoreFileJobTest {
 
                 when(fileSearch.search()).thenReturn(files);
                 when(fileSearch.setFileNameRegexFilter(any())).thenReturn(fileSearch);
-                when(sftpService.upload(eq(sftpClass), any(File.class))).thenReturn(true);
+                when(sftpService.upload(eq(sftpClass), any(File.class), anyLong(), anyLong()))
+                    .thenReturn(true);
 
                 Job.Result result = contentStoreFileJob.uploadFiles();
                 assertEquals(5, result.getMetaData().size(),
@@ -427,7 +429,7 @@ public class ContentStoreFileJobTest {
                 verify(fileSearch, times(1)).setFileNameRegexFilter(fileNameRegex);
                 for (File file : files) {
                     fileUtilsMock.verify(() -> FileUtils.deleteFile(eq(file)), times(1));
-                    verify(sftpService, times(1)).upload(sftpClass, file);
+                    verify(sftpService, times(1)).upload(sftpClass, file, 0, 0);
                     verify(databaseService, times(1))
                         .executeUpdate(connection, UPDATE_SQL_QUERY, file.getName(), fileType);
                 }
@@ -455,7 +457,7 @@ public class ContentStoreFileJobTest {
 
                 when(fileSearch.search()).thenReturn(files);
                 when(fileSearch.setFileNameRegexFilter(any())).thenReturn(fileSearch);
-                when(sftpService.upload(eq(sftpClass), any(File.class))).thenReturn(true);
+                when(sftpService.upload(eq(sftpClass), any(File.class), anyLong(), anyLong())).thenReturn(true);
 
                 SQLException sqlException = new SQLException("Forced sql exception");
                 for (File file : files) {
@@ -484,7 +486,7 @@ public class ContentStoreFileJobTest {
 
                 for (File file : files) {
                     fileUtilsMock.verify(() -> FileUtils.deleteFile(eq(file)), times(1));
-                    verify(sftpService, times(1)).upload(sftpClass, file);
+                    verify(sftpService, times(1)).upload(sftpClass, file, 0, 0);
                     verify(databaseService, times(1))
                         .executeUpdate(connection, UPDATE_SQL_QUERY, file.getName(), fileType);
                 }
@@ -507,12 +509,12 @@ public class ContentStoreFileJobTest {
 
                 when(fileSearch.search()).thenReturn(files);
                 when(fileSearch.setFileNameRegexFilter(any())).thenReturn(fileSearch);
-                when(sftpService.upload(eq(sftpClass), any(File.class))).thenReturn(false);
+                when(sftpService.upload(eq(sftpClass), any(File.class), anyLong(), anyLong())).thenReturn(false);
 
                 SQLException sqlException = new SQLException("Forced sql exception");
                 for (File file : files) {
                     fileUtilsMock.when(() -> databaseService.executeUpdate(connection,
-                            UPDATE_SQL_FAILED_QUERY, file.getName(), fileType)).thenThrow(sqlException);
+                        UPDATE_SQL_FAILED_QUERY, file.getName(), fileType)).thenThrow(sqlException);
                 }
 
                 Job.Result result = contentStoreFileJob.uploadFiles();
@@ -535,7 +537,7 @@ public class ContentStoreFileJobTest {
 
                 for (File file : files) {
                     fileUtilsMock.verify(() -> FileUtils.deleteFile(eq(file)), times(1));
-                    verify(sftpService, times(1)).upload(sftpClass, file);
+                    verify(sftpService, times(1)).upload(sftpClass, file, 0, 0);
                     verify(databaseService, times(1))
                         .executeUpdate(connection, UPDATE_SQL_FAILED_QUERY, file.getName(), fileType);
                 }
@@ -573,7 +575,7 @@ public class ContentStoreFileJobTest {
 
         @Test
         @SuppressWarnings("VariableDeclarationUsageDistance")
-        //Required for mocks setup
+//Required for mocks setup
         void negativeParticularSuccess() throws IOException {
             try (MockedStatic<FileUtils> fileUtilsMock = Mockito.mockStatic(FileUtils.class);
                  MockedStatic<FileSearch> fileSearchMock = Mockito.mockStatic(FileSearch.class)) {
@@ -591,9 +593,9 @@ public class ContentStoreFileJobTest {
                 when(fileSearch.search()).thenReturn(allFiles);
                 when(fileSearch.setFileNameRegexFilter(any())).thenReturn(fileSearch);
                 for (File file : workingFiles) {
-                    when(sftpService.upload(sftpClass, file)).thenReturn(true);
+                    when(sftpService.upload(sftpClass, file, 0, 0)).thenReturn(true);
                 }
-                when(sftpService.upload(sftpClass, failedFile)).thenReturn(false);
+                when(sftpService.upload(sftpClass, failedFile, 0, 0)).thenReturn(false);
 
 
                 Job.Result result = contentStoreFileJob.uploadFiles();
@@ -616,10 +618,10 @@ public class ContentStoreFileJobTest {
                 verify(fileSearch, times(1)).setFileNameRegexFilter(fileNameRegex);
 
                 for (File file : workingFiles) {
-                    verify(sftpService, times(1)).upload(sftpClass, file);
+                    verify(sftpService, times(1)).upload(sftpClass, file, 0, 0);
                     fileUtilsMock.verify(() -> FileUtils.deleteFile(any()), times(4));
                 }
-                verify(sftpService, times(1)).upload(sftpClass, failedFile);
+                verify(sftpService, times(1)).upload(sftpClass, failedFile, 0, 0);
                 fileUtilsMock.verify(() -> FileUtils.deleteFile(failedFile), times(1));
                 assertEquals(Status.PARTIAL_SUCCESS, result.getStatus());
                 assertEquals("1 files failed to upload out of 4",
@@ -650,7 +652,7 @@ public class ContentStoreFileJobTest {
 
                 when(fileSearch.search()).thenReturn(uploadFiles);
                 when(fileSearch.setFileNameRegexFilter(any())).thenReturn(fileSearch);
-                when(sftpService.upload(sftpClass, files)).thenReturn(files);
+                when(sftpService.upload(sftpClass, files, 1, 1)).thenReturn(files);
 
                 Job.Result result = contentStoreFileJob.uploadFiles();
                 assertEquals(8, result.getMetaData().size(), "Expect 8 metadata entries");
@@ -667,7 +669,7 @@ public class ContentStoreFileJobTest {
                 verify(fileSearch, times(1)).setFileNameRegexFilter(fileNameRegex);
 
                 for (File file : files) {
-                    verify(sftpService, times(1)).upload(sftpClass, file);
+                    verify(sftpService, times(1)).upload(sftpClass, file, 0, 0);
                     fileUtilsMock.verify(() -> FileUtils.deleteFile(any()), times(3));
                 }
 
@@ -694,8 +696,7 @@ public class ContentStoreFileJobTest {
                                           Object[] procedureArguments, String fileNameRegex,
                                           Class<? extends Sftp> sftpClass) {
             super(sftpService, databaseService, ftpDirectory, databaseConfig, fileType, procedureName,
-                procedureArguments,
-                fileNameRegex, sftpClass);
+                procedureArguments, fileNameRegex, sftpClass, 0, 0);
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/ContentStoreFileJobTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/job/execution/jobs/contentstore/ContentStoreFileJobTest.java
@@ -574,8 +574,7 @@ public class ContentStoreFileJobTest {
         }
 
         @Test
-        @SuppressWarnings("VariableDeclarationUsageDistance")
-//Required for mocks setup
+        @SuppressWarnings("VariableDeclarationUsageDistance")//Required for mocks setup
         void negativeParticularSuccess() throws IOException {
             try (MockedStatic<FileUtils> fileUtilsMock = Mockito.mockStatic(FileUtils.class);
                  MockedStatic<FileSearch> fileSearchMock = Mockito.mockStatic(FileSearch.class)) {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7921)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=222)


### Change description ###
Print and Payment files are transferred from the Juror system to BAIS (which acts a staging server) using FTP. These FTP transfers fail from time to time, usually when the connection is established with a ‘connection reset by peer’ error.
A retry mechanism should be introduced in order to reduce the number of failures.  The impact is delayed letters and payments.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
