### PR TITLE
Task/JS-571 Compiler flag prevents build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = 'uk.gov.hmcts.juror'
-version = '5.22.0'
+version = '5.23.0'
 
 java {
   toolchain {
@@ -74,7 +74,7 @@ configurations {
 }
 
 tasks.withType(JavaCompile) {
- // options.compilerArgs << "-Xlint:unchecked" << "-Werror"
+  options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
 // https://github.com/gradle/gradle/issues/16791

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = 'uk.gov.hmcts.juror'
-version = '5.23.0'
+version = '5.24.0'
 
 java {
   toolchain {

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -62,9 +62,6 @@
     <exclude name="CommentSize"/>
     <exclude name="UncommentedEmptyMethodBody"/>
   </rule>
-  <rule ref="category/java/errorprone.xml">
-    <exclude name="BeanMembersShouldSerialize"/>
-  </rule>
   <rule ref="category/java/multithreading.xml"/>
   <rule ref="category/java/performance.xml"/>
   <rule ref="category/java/security.xml"/>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/JS-571

### Change description ###

In order to get the api's to build successfully after the spring boot update the complier flag 
tasks.withType(JavaCompile) {
options.compilerArgs << "-Xlint:unchecked" //<< "-Werror"
{color}}

was temporarily commented out this flag sets compiler build warnings as errors

uncomment flag and resolve all warnings , highlight those that require futher investigation 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
