### PR TITLE
JS-768 Upadte juror-scheduler-execution to java version 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,7 +197,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.github.hmcts:juror-spring-support-library:1.1.5:plain@jar'
+  implementation 'com.github.hmcts:juror-spring-support-library:1.2.0:plain@jar'
   implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
 
   implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ version = '5.24.0'
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 


### PR DESCRIPTION
Update juror scheduler execution to java version 21


https://tools.hmcts.net/jira/browse/JS-768


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
